### PR TITLE
feat: add composer bin reference for simpler usage

### DIFF
--- a/bin/imposter
+++ b/bin/imposter
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+$autoloadPaths = [
+    dirname(__DIR__, 2) . '/autoload.php',
+    dirname(__DIR__, 1) . '/vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php',
+];
+
+foreach ($autoloadPaths as $autoload) {
+    if (is_file($autoload)) {
+        require $autoload;
+        break;
+    }
+    fwrite(STDERR,
+        'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+        'php composer.phar install'.PHP_EOL
+    );
+    exit(1);
+}
+
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+
+$application->add(new \Imposter\Server\Command\Start());
+
+$application->run();

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,10 @@
             "Imposter\\" : ["test/unit", "test/api"]
         }
     },
+    "bin": [
+        "bin/imposter",
+        "bin/Imposter.php"
+    ],
     "config": {
         "platform": {
             "php": "7.0"


### PR DESCRIPTION
The new composer bin param allow to directly call vendor/bin/imposter after composer install